### PR TITLE
Update Darius.cs

### DIFF
--- a/SigmaSeries/Plugins/Darius.cs
+++ b/SigmaSeries/Plugins/Darius.cs
@@ -17,7 +17,7 @@ namespace SigmaSeries.Plugins
         {
             Q = new Spell(SpellSlot.Q, 425);
             W = new Spell(SpellSlot.W, 210);
-            E = new Spell(SpellSlot.E, 540);
+            E = new Spell(SpellSlot.E, 550);
             R = new Spell(SpellSlot.R, 460);
 
             E.SetSkillshot(0.5f, 300f, 1500f, false, SkillshotType.SkillshotCone);


### PR DESCRIPTION
Words from a Rioter
"Nice question, got curious myself and had a quick look at the spell's files. The actual range is 550, though the range display indicator is indeed set to 540. At a guess during Darius' development or balancing someone decided to test out a slight range drop, realized it didn't do what they'd hoped and reverted the change, without reverting the display indicator change."